### PR TITLE
feat(styles): add style for figcaption

### DIFF
--- a/theme/assets/css/main.css
+++ b/theme/assets/css/main.css
@@ -44,6 +44,14 @@ blockquote {
   padding-left: 2em;
 }
 
+figcaption {
+  color: var(--dove-gray);
+  font-size: .9em;
+  font-style: italic;
+  line-height: 1.8em;
+  text-align: center;
+}
+
 h1 {
   font-family: 'Red Hat Display', sans-serif;
   font-size: 3em;


### PR DESCRIPTION
### what

add styles for `figcaption` which is what ghost uses for image captions

before:

![image](https://user-images.githubusercontent.com/2454505/89087703-000b4280-d34a-11ea-821e-509c335b08ba.png)

---

after:

![image](https://user-images.githubusercontent.com/2454505/89087694-f08bf980-d349-11ea-80bf-a7e17941eee0.png)
