### PR TITLE
fix(footer): make copyright date dynamic

### DIFF
--- a/theme/partials/footer.hbs
+++ b/theme/partials/footer.hbs
@@ -31,6 +31,6 @@
   </div>
 </footer>
 <footer class="copyright">
-  &copy; 2020 InterviewPlanner | Made with <i class="fas fa-heart"></i> in San Francisco
+  &copy; {{date format="YYYY"}} InterviewPlanner | Made with <i class="fas fa-heart"></i> in San Francisco
 </footer>
 


### PR DESCRIPTION
### what

instead of hard-coding 2020, it dynamically picks the current year, like our main site